### PR TITLE
Adding timeout parameter and DNS resolving

### DIFF
--- a/atomicpuppy/__init__.py
+++ b/atomicpuppy/__init__.py
@@ -36,7 +36,8 @@ class AtomicPuppy:
                 stream_name=s,
                 loop=self._loop,
                 instance_name=self.config.instance_name,
-                subscriptions_store=subscription_info_store)
+                subscriptions_store=subscription_info_store,
+                timeout=self.config.timeout)
             for s in self.config.streams
         ]
         self.tasks = [s.start_consuming() for s in self.readers]

--- a/atomicpuppy/atomicpuppy.py
+++ b/atomicpuppy/atomicpuppy.py
@@ -330,6 +330,10 @@ class StreamFetcher:
             except HttpServerError as e:
                 self.log(e, uri)
                 yield from self.sleep(s)
+            except TimeoutError as e:
+                self.log(e, uri)
+                yield from self.sleep(s)
+
 
 
 class EventRaiser:

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -489,7 +489,7 @@ class When_a_disconnection_error_occurs_during_fetch(StreamReaderContext):
 class When_a_timeout_error_occurs_during_fetch(StreamReaderContext):
 
     """
-    If we get a Timeout error, then it's a network level issue'. Retry with
+    If we get a Timeout error, then it's a network level issue. Retry with
     a backoff.
     """
 

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -56,7 +56,8 @@ class StreamReaderContext:
             counter_factory=self.create_counter,
             instance_name='foo',
             host=self._host,
-            port=self._port)
+            port=self._port,
+            timeout=20)
 
         subscriptions_store = SubscriptionInfoStore(config, self.counter)
         if last_read != -1:
@@ -67,6 +68,7 @@ class StreamReaderContext:
             loop=self._loop,
             instance_name='foo',
             subscriptions_store=subscriptions_store,
+            timeout=config.timeout,
             nosleep=nosleep)
         return self._reader
 

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -486,6 +486,39 @@ class When_a_disconnection_error_occurs_during_fetch(StreamReaderContext):
                    for r in self._log._logs))
 
 
+class When_a_timeout_error_occurs_during_fetch(StreamReaderContext):
+
+    """
+    If we get a Timeout error, then it's a network level issue'. Retry with
+    a backoff.
+    """
+
+    _log = SpyLog()
+
+    def given_a_disconnection_error(self):
+            self.http.registerCallbacksUri(
+                'http://eventstore.local:2113/streams/newstream/0/forward/20',
+                [
+                    lambda: exec('raise aiohttp.errors.TimeoutError()'),
+                    lambda: exec('raise ValueError()')
+                ]
+            )
+
+    def because_we_start_the_reader(self):
+        self._reader = self.subscribeTo("newstream", -1, nosleep=True)
+        with(self._log.capture()):
+            mock = self.http.getMock()
+            with patch("aiohttp.request", new=mock):
+                self._loop.run_until_complete(
+                    self._reader.start_consuming()
+                )
+
+    def it_should_log_a_warning(self):
+        assert(any(r.msg == "Error occurred while requesting %s"
+                   and r.levelno == logging.WARNING
+                   for r in self._log._logs))
+
+
 """
 If we get a ClientResponseError error, then it's a network level issue. Retry with
 a backoff.


### PR DESCRIPTION
This PR fixes two problems:
-when requested server is unavailable, aiohttp will never timeout and the process will stall,
-aiohttp never clears the cached DNS hostname, so if we run the process in an inifnte loop this makes the process to stall if node becomes somehow unavailable (eg. change IP).