### PR TITLE
Add tox.ini to run tests on Python 3.4 and 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ loop.add_signal_handler(signal.SIGINT, stop)
 # and to start it call start.
 loop.run_until_complete(ap.start())
 ```
+
+
+## Run the tests
+
+A `tox.ini` file is provided to run the tests with different versions of Python.
+
+To run the tests:
+
+1. Make sure you have the Python 3.4 headers installed (on Ubuntu this is `apt-get install python3.4-dev`)
+2. Make sure you have the Python 3.5 headers installed (on Ubuntu this is `apt-get install python3.5-dev`)
+3. `pip install test-requirements.txt` from the root folder of the repository
+4. Run `tox` from the root folder of the repository

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ HTTPretty==0.8.10
 Contexts==0.10.2		
 fakeredis==0.6.1		
 freezegun==0.3.3
+tox==2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py34,py35
+[testenv]
+deps= -rtest-requirements.txt
+commands=run-contexts tests


### PR DESCRIPTION
This PR adds `tox` support so that we can run tests against newer versions of Python.