### PR TITLE
Fixes #8

### DIFF
--- a/atomicpuppy/atomicpuppy.py
+++ b/atomicpuppy/atomicpuppy.py
@@ -61,6 +61,11 @@ SubscriptionConfig = namedtuple('SubscriptionConfig', ['streams',
                                                        'page_size'])
 
 
+# this function moved from the futures class to the module at some point, 
+# so we need to know where to look for it.
+_SET_RESULT_UNLESS_CANCELLED_MODULE = hasattr(asyncio.futures, '_set_result_unless_cancelled')
+
+
 class Event:
 
     def __init__(self, id, type, data, stream, sequence):
@@ -414,10 +419,17 @@ class StreamFetcher:
         if(self._nosleep):
             return
         self._sleep = asyncio.futures.Future(loop=self._loop)
-        self._sleep._loop.call_later(
-            delay,
-            self._sleep._set_result_unless_cancelled,
-            None)
+
+        if _SET_RESULT_UNLESS_CANCELLED_MODULE:
+            self._sleep._loop.call_later(
+                delay,
+                asyncio.futures._set_result_unless_cancelled,
+                self._sleep, None)
+        else:    
+             self._sleep._loop.call_later(
+                delay,
+                self._sleep._set_result_unless_cancelled,
+                None)
         self._log.debug("retrying fetch in %d seconds", delay)
         yield from self._sleep
 


### PR DESCRIPTION
With this commit, we check to see whether the
_set_result_unless_cancelled_function has moved to the asyncio.futures
module. If so, we invoke it there instead of on the Future class.

Fixes the attributeerror